### PR TITLE
chore: switch to create root

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
-import ReactDOM from 'react-dom';
 import './index.css';
 import App from './App';
+import { createRoot } from 'react-dom/client';
 
-ReactDOM.render(
+const container = document.getElementById('root') as HTMLElement;
+const root = createRoot(container);
+root.render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>,
-  document.getElementById('root')
+  </React.StrictMode>
 );


### PR DESCRIPTION
Due to changes to react 18 we should not use `ReactDom.render` but `createRoot` unless we actually want to use this as a checkpoint for the task whether someone notices that. 

Before:
![image](https://user-images.githubusercontent.com/29208458/197124897-7d9c6da2-079e-4d84-b933-209894d85739.png)

After:
![image](https://user-images.githubusercontent.com/29208458/197124951-29f94de2-a1b2-417b-b931-04352c87604d.png)

